### PR TITLE
Remove dependency for glibc-2.2.5

### DIFF
--- a/script/script.c
+++ b/script/script.c
@@ -7,7 +7,7 @@
 #include <ctype.h>
 #include <unistd.h>
 
-__asm__(".symver memcpy ,memcpy@GLIBC_2.2.5");
+//__asm__(".symver memcpy ,memcpy@GLIBC_2.2.5");
 
 int parser_script(void *pbuf, int script_len, FILE *hfile);
 //------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
memcpy is just used for copying input filename to dst filename. No need of glibc-2.2.5 dependency.
